### PR TITLE
pyecmd: Make fapi2 test conditional on fapi2 being built into ecmd

### DIFF
--- a/ecmd-core/pyecmd/test_api.py
+++ b/ecmd-core/pyecmd/test_api.py
@@ -1,6 +1,10 @@
 from pyecmd import *
 
-with Ecmd(fapi2="ver1"):
+extensions = {}
+if hasattr(ecmd, "fapi2InitExtension"):
+     extensions["fapi2"] = "ver1"
+
+with Ecmd(**extensions):
      t = loopTargets("pu", ECMD_SELECTED_TARGETS_LOOP)[0]
      data = t.getScom(0x1234)
      t.putScom(0x1234, 0x10100000)
@@ -13,11 +17,13 @@ with Ecmd(fapi2="ver1"):
      retval = t.queryFileLocationHidden2(ECMD_FILE_SCANDEF, "")
      for loc in retval.fileLocations:
          testval = loc.textFile + loc.hashFile + retval.version
-     try:
-          t.fapi2GetAttr("ATTR_DOES_NOT_EXIST")
-          assert(""=="That was supposed to throw!")
-     except KeyError:
-          pass
 
-     t.fapi2SetAttr("ATTR_CHIP_ID", 42)
-     assert(42 == t.fapi2GetAttr("ATTR_CHIP_ID"))
+     if "fapi2" in extensions:
+         try:
+              t.fapi2GetAttr("ATTR_DOES_NOT_EXIST")
+              assert(""=="That was supposed to throw!")
+         except KeyError:
+              pass
+
+         t.fapi2SetAttr("ATTR_CHIP_ID", 42)
+         assert(42 == t.fapi2GetAttr("ATTR_CHIP_ID"))


### PR DESCRIPTION
Here's my attempt at making the pyecmd API test work with and without fapi2 built. Tested in both configurations (with and without fapi) on my system.